### PR TITLE
Basic Host Management and Enrollment Logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/src/index.js",
+  "min_host_ver": "1.0.0",
   "scripts": {
     "build": "tsc",
     "build-menu": "ts-node menu/build-items.ts",
@@ -19,6 +20,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@types/node-fetch": "^2.6.1",
+    "@types/semver-compare": "^1.0.1",
     "@urql/core": "^2.5.0",
     "axios": "^0.27.2",
     "cors": "^2.8.5",
@@ -29,7 +31,8 @@
     "mongoose": "^6.4.6",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.6",
-    "random-words": "^1.2.0"
+    "random-words": "^1.2.0",
+    "semver-compare": "^1.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bagelbot",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/src/index.js",
   "min_host_ver": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/node-fetch": "^2.6.1",
     "@urql/core": "^2.5.0",
     "axios": "^0.27.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "elasticlunr": "^0.9.5",
     "express": "^4.18.1",
@@ -31,6 +32,7 @@
     "random-words": "^1.2.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.12",
     "@types/elasticlunr": "^0.9.5",
     "@types/express": "^4.17.13",
     "@types/graphql": "^14.5.0",

--- a/src/coin/hosts.ts
+++ b/src/coin/hosts.ts
@@ -1,0 +1,95 @@
+import fetch from 'node-fetch';
+import { cacheWithTimeout } from '../db/caching';
+import { isHostAlive } from './utils';
+
+const HOST_SEEDS = [
+    'seed01-bxch.erwijet.com',
+    'seed02-bxch.erwijet.com',
+    'seed03-bxch.erwijet.com'
+];
+
+const PROTOCOL = 'https';
+
+//
+
+type HostGraphEnt = {
+    host: string,
+    edges: string[]
+}
+
+//
+
+export async function getDirectPeers(host: string): Promise<string[]> {
+    try {
+        const res = await fetch(`${PROTOCOL}://${host}/node/peers`, {
+            method: 'GET',
+            headers: {
+                accept: 'application/json'
+            }
+        })
+
+        return (await res.json()).map((ent: {url: string}) => ent.url);
+    } catch { return [] as string[] };
+}
+
+export async function getHostGraph(): Promise<HostGraphEnt[]> {
+    const hosts = [] as HostGraphEnt[];
+
+    // result cached for 5 seconds
+    const exploreHostRec = cacheWithTimeout(async (host: string) => {
+        if (hosts.some(ent => ent.host == host) || !(await isHostAlive(host))) return;
+        const edges = await getDirectPeers(host);
+
+        hosts.push({
+            host,
+            edges: await getDirectPeers(host)
+        });
+
+        for (let edge of edges) {
+            await exploreHostRec(edge);
+        }
+
+        return true;
+    }, 5 * 1000);
+
+    for (let seed of HOST_SEEDS) {
+        await exploreHostRec(seed);
+    }
+
+    return hosts;
+}
+
+export async function getRandomHosts(count: number): Promise<HostGraphEnt[]> {
+    const hosts = await getHostGraph();
+    return hosts.sort(() => 0.5 - Math.random()).slice(0, Math.min(count, hosts.length));
+}
+
+export async function registerNewHost(host: string, peerCount: number) {
+    const peers = await getRandomHosts(peerCount);
+
+    // add host to peer list of each selected peer
+    await Promise.all(peers.map(peer =>
+        fetch(`${PROTOCOL}://${peer.host}/node/peers`, {
+            method: 'POST',
+            headers: {
+                'accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ url: host })
+        })
+    ));
+
+    // add each peer to the peer list of selected host
+    await Promise.all(peers.map(peer => 
+        fetch(`${PROTOCOL}://${host}/node/peers`, {
+            method: 'POST',
+            headers: {
+                'accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ url: peer.host })
+        })
+    ));
+
+    return peers.map(peer => peer.host);
+}

--- a/src/coin/utils.ts
+++ b/src/coin/utils.ts
@@ -45,3 +45,16 @@ export async function newCoinUser(): Promise<[Password, Wallet, Address]> {
 
   return [password, wallet, address];
 }
+
+export async function isHostAlive(host: string) {
+  try {
+    const res = await fetch(`https://${host}/blockchain`, {
+      method: 'GET',
+      headers: {
+	accept: 'text/html'
+      }
+    });
+
+    return res.status - 400 < 0; // status code is not in the 4XX range or above
+  } catch { return false; }
+}

--- a/src/coin/utils.ts
+++ b/src/coin/utils.ts
@@ -1,5 +1,6 @@
 import randomWords from "random-words";
 import fetch from "node-fetch";
+import semver from 'semver-compare';
 
 type Password = string;
 type Wallet = string;
@@ -57,4 +58,14 @@ export async function isHostAlive(host: string) {
 
     return res.status - 400 < 0; // status code is not in the 4XX range or above
   } catch { return false; }
+}
+
+export async function checkHostVer(host: string) {
+  const MIN_VER = '1.0.0';
+
+  try {
+    const res = await fetch(`https://${host}/meta/pkg`);
+    const reportedVer = (await res.json()).version;
+    return semver(reportedVer, MIN_VER) != -1;
+  } catch { return false }
 }

--- a/src/db/caching.ts
+++ b/src/db/caching.ts
@@ -9,3 +9,20 @@ export default function cache<P extends any[], R>(fn: (...params: P) => Promise<
     return invocationMap[thisInvocationKey];
   };
 }
+
+export function cacheWithTimeout<P extends any[], R>(fn: (...params: P) => Promise<R>, ttl: number): typeof fn {
+  const invocationMap = {} as { [k: string]: R };
+
+  setTimeout(() =>
+      Object.keys(invocationMap).forEach(key => invocationMap.hasOwnProperty(key) && delete invocationMap[key]),
+      ttl);
+
+
+  return async function (...params: P): Promise<R> {
+    const thisInvocationKey = JSON.stringify(params);
+    if (typeof invocationMap[thisInvocationKey] == "undefined")
+      invocationMap[thisInvocationKey] = await fn(...params);
+
+    return invocationMap[thisInvocationKey];
+  };
+}

--- a/src/db/models/Host.ts
+++ b/src/db/models/Host.ts
@@ -1,0 +1,5 @@
+import mongoose from 'mongoose';
+import HostSchema from '../schemas/Host';
+
+const HostModel = mongoose.model('Host', HostSchema);
+export default HostModel;

--- a/src/db/schemas/Host.ts
+++ b/src/db/schemas/Host.ts
@@ -1,0 +1,11 @@
+import { Schema } from "mongoose";
+
+export default new Schema({
+    host: { type: 'string' },
+    last_online: { type: 'number' }
+});
+
+export interface HostSpec {
+    host: string,
+    last_online: string
+}

--- a/src/db/util.ts
+++ b/src/db/util.ts
@@ -6,9 +6,7 @@ import MenuItemModel from "./models/MenuItem";
 export async function ensureConnected() {
   const PRIMARY_CONN_STR = process.env.MONGO_URL;
 
-  console.log({ PRIMARY_CONN_STR });
-
-  await mongoose.connect(PRIMARY_CONN_STR!);
+  await mongoose.connect(PRIMARY_CONN_STR!, { ssl: false, authSource: 'admin' });
 }
 
 export const getMenuItems = cache(async () => {

--- a/src/routes/v1/coin.ts
+++ b/src/routes/v1/coin.ts
@@ -1,26 +1,26 @@
-import { Router } from 'express';
-import { ensureConnected } from '../../db/util';
-import { getBalance } from '../../coin/payment';
-import UserModel from '../../db/models/User';
+import { Router } from "express";
+import { ensureConnected } from "../../db/util";
+import { getBalance } from "../../coin/payment";
+import UserModel from "../../db/models/User";
 
 const coinRouter = Router();
 
-coinRouter.get('/', async (req, res) => {
-    await ensureConnected();
+coinRouter.get("/", async (req, res) => {
+  await ensureConnected();
 
-    const users = await UserModel.find({});
-    const ret = [];
+  const users = await UserModel.find({});
+  const ret = [] as { first_name: string; last_name: string; bryxcoin_balance: number }[];
 
-    for (let usr of users) {
-        const balance = await getBalance(usr.bryxcoin_address!);
-        ret.push({
-            first_name: usr.first_name,
-            last_name: usr.last_name,
-            bryxcoin_balance: balance
-        })
-    }
+  for (let usr of users) {
+    const balance = await getBalance(usr.bryxcoin_address!);
+    ret.push({
+      first_name: usr.first_name!,
+      last_name: usr.last_name!,
+      bryxcoin_balance: balance,
+    });
+  }
 
-    return res.json(ret);
+  return res.json(ret);
 });
 
 export default coinRouter;

--- a/src/routes/v1/hosts.ts
+++ b/src/routes/v1/hosts.ts
@@ -1,8 +1,7 @@
-import { json, Router } from 'express';
-import { ensureConnected } from '../../db/util';
-import HostModel from '../../db/models/Host';
-import { isHostAlive } from '../../coin/utils';
+import { Router } from 'express';
 import { getHostGraph, getRandomHosts, registerNewHost } from '../../coin/hosts';
+
+import pkg from '../../../package.json';
 
 const hostsRouter = Router();
 
@@ -16,42 +15,16 @@ hostsRouter.get('/rand/:n', async (req, res) => {
     return res.json(await getRandomHosts(Number.parseInt(n)));
 });
 
-// hostsRouter.get('/', async (req, res) => {
-//     await ensureConnected();
-//     const hosts = await HostModel.find({ });
-
-//     return res.json(hosts);
-// });
+hostsRouter.get('/meta/compliance', (req, res) => {
+    return res.json({
+        min_version: (pkg as typeof pkg & { min_host_ver: string }).min_host_ver
+    })
+});
 
 hostsRouter.post('/', async (req, res) => {
     const { host } = req.body;
     return res.json(await registerNewHost(host, 3));
 });
 
-// hostsRouter.put('/:host/refresh', async (req, res) => {
-//     await ensureConnected();
-//     const { host } = req.params;
-
-//     const hostRecord = await HostModel.findOne({ host });
-//     if (!hostRecord) return res.status(404).end('Not Found');
-
-//     hostRecord.last_online = Date.now();
-//     await hostRecord.save();
-
-//     return res.json(hostRecord);
-// });
-
-// hostsRouter.delete('/:host', async (req, res) => {
-//     await ensureConnected();
-//     const { host } = req.params;
-
-//     const hostRecord = await HostModel.findOne({ host });
-//     if (!hostRecord) return res.status(404).end('Not Found');
-
-//     if (await isHostAlive(host)) return res.status(400).end('Illegal. Host is alive');
-
-//     await hostRecord.delete();
-//     return res.status(204).end();
-// });
 
 export default hostsRouter;

--- a/src/routes/v1/hosts.ts
+++ b/src/routes/v1/hosts.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { ensureConnected } from '../../db/util';
+import HostModel from '../../db/models/Host';
+
+const hostsRouter = Router();
+
+hostsRouter.get('/', async (req, res) => {
+    await ensureConnected();
+    const hosts = await HostModel.find({ });
+
+    return res.json(hosts);
+});
+
+hostsRouter.post('/', async (req, res) => {
+    await ensureConnected();
+    const { host } = req.body;
+    return res.json(await HostModel.create({ host }));
+});
+
+hostsRouter.put('/:host/refresh', async (req, res) => {
+    await ensureConnected();
+    const { host } = req.params;
+
+    const hostRecord = await HostModel.findOne({ host });
+    if (!hostRecord) return res.status(404).end('Not Found');
+
+    hostRecord.last_online = Date.now();
+    await hostRecord.save();
+
+    return res.json(hostRecord);
+});
+
+export default hostsRouter;

--- a/src/routes/v1/hosts.ts
+++ b/src/routes/v1/hosts.ts
@@ -1,33 +1,57 @@
-import { Router } from 'express';
+import { json, Router } from 'express';
 import { ensureConnected } from '../../db/util';
 import HostModel from '../../db/models/Host';
+import { isHostAlive } from '../../coin/utils';
+import { getHostGraph, getRandomHosts, registerNewHost } from '../../coin/hosts';
 
 const hostsRouter = Router();
 
-hostsRouter.get('/', async (req, res) => {
-    await ensureConnected();
-    const hosts = await HostModel.find({ });
 
-    return res.json(hosts);
+hostsRouter.get('/', async (req, res) => {
+    return res.json(await getHostGraph());
 });
+
+hostsRouter.get('/rand/:n', async (req, res) => {
+    const { n } = req.params;
+    return res.json(await getRandomHosts(Number.parseInt(n)));
+});
+
+// hostsRouter.get('/', async (req, res) => {
+//     await ensureConnected();
+//     const hosts = await HostModel.find({ });
+
+//     return res.json(hosts);
+// });
 
 hostsRouter.post('/', async (req, res) => {
-    await ensureConnected();
     const { host } = req.body;
-    return res.json(await HostModel.create({ host }));
+    return res.json(await registerNewHost(host, 3));
 });
 
-hostsRouter.put('/:host/refresh', async (req, res) => {
-    await ensureConnected();
-    const { host } = req.params;
+// hostsRouter.put('/:host/refresh', async (req, res) => {
+//     await ensureConnected();
+//     const { host } = req.params;
 
-    const hostRecord = await HostModel.findOne({ host });
-    if (!hostRecord) return res.status(404).end('Not Found');
+//     const hostRecord = await HostModel.findOne({ host });
+//     if (!hostRecord) return res.status(404).end('Not Found');
 
-    hostRecord.last_online = Date.now();
-    await hostRecord.save();
+//     hostRecord.last_online = Date.now();
+//     await hostRecord.save();
 
-    return res.json(hostRecord);
-});
+//     return res.json(hostRecord);
+// });
+
+// hostsRouter.delete('/:host', async (req, res) => {
+//     await ensureConnected();
+//     const { host } = req.params;
+
+//     const hostRecord = await HostModel.findOne({ host });
+//     if (!hostRecord) return res.status(404).end('Not Found');
+
+//     if (await isHostAlive(host)) return res.status(400).end('Illegal. Host is alive');
+
+//     await hostRecord.delete();
+//     return res.status(204).end();
+// });
 
 export default hostsRouter;

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import usersRouter from './users';
 import coinRouter from './coin';
 import tabsRouter from './tabs';
+import hostsRouter from './hosts';
 import transactionsRouter from './transaction';
 
 const v1Router = Router();
@@ -10,5 +11,6 @@ v1Router.use('/users', usersRouter);
 v1Router.use('/coin', coinRouter);
 v1Router.use('/tabs', tabsRouter);
 v1Router.use('/transactions', transactionsRouter);
+v1Router.use('/hosts', hostsRouter);
 
 export default v1Router;

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -5,7 +5,11 @@ import tabsRouter from './tabs';
 import hostsRouter from './hosts';
 import transactionsRouter from './transaction';
 
+import cors from 'cors';
+
 const v1Router = Router();
+
+v1Router.use(cors());
 
 v1Router.use('/users', usersRouter);
 v1Router.use('/coin', coinRouter);

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,11 @@
   version "1.2.4"
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz"
 
+"@types/semver-compare@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
+  integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz"
@@ -685,6 +690,11 @@ saslprep@^1.0.3:
   resolved "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz"
   dependencies:
     sparse-bitfield "^3.0.3"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
 send@0.18.0:
   version "0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,6 +80,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@^2.8.12":
+  version "2.8.12"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
+  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+
 "@types/elasticlunr@^0.9.5":
   version "0.9.5"
   resolved "https://registry.npmjs.org/@types/elasticlunr/-/elasticlunr-0.9.5.tgz"
@@ -269,6 +274,14 @@ cookie-signature@1.0.6:
 cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -584,6 +597,11 @@ node-fetch@^2.6.6:
   dependencies:
     whatwg-url "^5.0.0"
 
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz"
@@ -787,7 +805,7 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
 


### PR DESCRIPTION
## Significant Changes:

- `POST /v1/hosts` with body `{ host: string }`: enroll a new host and auto-link to 3 random current hosts the network based on 3 seed nodes: `seed01..3-bxch.erwijet.com`
- `GET /v1/hosts`: Traverse entire network to list all nodes, as well as an adjacency chart for host peers
- `GET /v1/hosts/meta/compliance`: return compliance information for hosts to check themselves against. Additionally, future versions of the API will enforce compliance requirements as well.
- `GET /v1/hosts/rand/:n`: return a list of `n` random hosts from the network that are alive, along with their adjacency lists.

## Lesser Changes:

- outdated files from previous project fork have been deleted and cleaned up
- base image now uses `node:16`, instead of `node:6` (cringe)