### PR TITLE
Tab Updates and New Mining Reward

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "",
   "main": "dist/src/index.js",
-  "min_host_ver": "1.0.0",
+  "min_host_ver": "1.1.0",
   "scripts": {
     "build": "tsc",
     "build-menu": "ts-node menu/build-items.ts",

--- a/src/routes/slash/tab.ts
+++ b/src/routes/slash/tab.ts
@@ -41,7 +41,7 @@ tabRouter.post("/", async (req, res) => {
       await curTab.save();
       await sendMessage(`-- <@${curTab.opener}> CLOSED THE BAGEL TAB --`);
       await sendMessage('```\nToday\'s Tab\n\n' + curTab.order_logs! + '\n```');
-      return res.end("Success! Your cart guid is `" + curTab.balsam_cart_guid);
+      return res.end("Success! Access your cart at https://www.toasttab.com/balsam-bagels/v3/?rl=1&cart=" + curTab.balsam_cart_guid);
     }
   } else {
     return res.end("Invalid option! Usage: `/tab <open|close>`");


### PR DESCRIPTION
## Significant Changes
- require version `>=1.1.0` for coin hosts as per the updates in [bagelbotdev/coin](https://github.com/bagelbotdev/coin)

## Lesser Changes
- Update close tab response to include full toasttab url of cart